### PR TITLE
WIP: Add new params to support ARM-on-x86 packaging

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -94,6 +94,11 @@ usage() {
     else
         echo -e "    INPUTS_BUILD_HOST                (optional) ${CYAN}present${NORMAL} $INPUTS_BUILD_HOST"
     fi
+    if [[ -z "$INPUTS_TARGET_PROCESSOR_ARCH" ]]; then
+        echo -e "    INPUTS_TARGET_PROCESSOR_ARCH     (optional) ${YELLOW}missing${NORMAL}"
+    else
+        echo -e "    INPUTS_TARGET_PROCESSOR_ARCH     (optional) ${CYAN}present${NORMAL} $INPUTS_TARGET_PROCESSOR_ARCH"
+    fi
     if [[ -z "$INPUTS_ARTIFACTS_TOKEN" ]]; then
         echo -e "    INPUTS_ARTIFACTS_TOKEN           (optional) ${YELLOW}missing${NORMAL}"
     else
@@ -207,5 +212,6 @@ docker run --name thing \
     -e INPUTS_SPEC_FILE="$INPUTS_SPEC" \
     -e INPUTS_BUILD_HOST="$INPUTS_BUILD_HOST" \
     -e INPUTS_ARTIFACTS_TOKEN="$INPUTS_ARTIFACTS_TOKEN" \
+    -e INPUTS_TARGET_PROCESSOR_ARCH="$INPUTS_TARGET_PROCESSOR_ARCH" \
     -v "$GITHUB_WORKSPACE/$INPUTS_PATH:/mnt/repo" \
     $docker_name

--- a/action.yml
+++ b/action.yml
@@ -6,22 +6,38 @@ name: Package and sign RPM
 description: Package and sign an RPM for the specified distribution.
 
 inputs:
+  #required inputs
   path:
     description: 'The path to the directory containing all the files needed to build the RPM.'
     required: true
   spec:
     description: 'The spec file to build.  The spec file must be located in the path.'
     required: true
+  #optional inputs
+  artifacts-token:
+    description: 'The token needed to fetch artifacts from private github repositories.'
+    required: false
+  build-host:
+    description: 'The build host to specify for inclusion into the RPM information.'
+    required: false
+  container-registry-token:
+    description: 'The token to use as the password to the container registry with if present.'
+    required: false
+  container-registry-url:
+    description: 'If specified, the non-dockerhub container URL.  For Github Containers specify "ghcr.io"'
+    required: false
   distro:
     description: 'The distribution to build on and target, or "custom" to provide your own dockerfile.'
     required: false
     default: custom
-  output-dir:
-    description: 'The destination directory to place the RPM and SRPM files.'
+  dockerfile-access-token:
+    description: 'The access token if needed to download the dockerfile from a protected repo.'
     required: false
-    default: output
-  build-host:
-    description: 'The build host to specify for inclusion into the RPM information.'
+  dockerfile-path:
+    description: 'The path from the repo to the file including the filename.  Used and required if "distro" is set to "custom".'
+    required: false
+  dockerfile-slug:
+    description: 'The github owner/repo where the dockerfile can be found.  Defaults to looking in the present repo unless specified.'
     required: false
   gpg-key:
     description: 'The GPG key used to sign the RPM. (requires gpg-name)'
@@ -29,26 +45,12 @@ inputs:
   gpg-name:
     description: 'The GPG name used to sign the RPM. (requires gpg-key)'
     required: false
-  dockerfile-slug:
-    description: 'The github owner/repo where the dockerfile can be found.  Defaults to looking in the present repo unless specified.'
+  output-dir:
+    description: 'The destination directory to place the RPM and SRPM files.'
     required: false
-  dockerfile-path:
-    description: 'The path from the repo to the file including the filename.  Used and required if "distro" is set to "custom".'
-    required: false
-  dockerfile-access-token:
-    description: 'The access token if needed to download the dockerfile from a protected repo.'
-    required: false
-  container-registry-url:
-    description: 'If specified, the non-dockerhub container URL.  For Github Containers specify "ghcr.io"'
-    required: false
-  container-registry-user:
-    description: 'The username to login to the container registry with if present.'
-    required: false
-  container-registry-token:
-    description: 'The token to use as the password to the container registry with if present.'
-    required: false
-  artifacts-token:
-    description: 'The token needed to fetch artifacts from private github repositories.'
+    default: output
+  target-processor-arch:
+    description: 'The target processor architecture to build the RPM for (e.g. x86_64, aarch64, etc.).'
     required: false
 
 runs:
@@ -57,20 +59,20 @@ runs:
     - id: rpm-package-action
       shell: bash
       run: |
-        INPUTS_PATH="${{ inputs.path }}" \
-        INPUTS_SPEC="${{ inputs.spec }}" \
+        INPUTS_ARTIFACTS_TOKEN="${{ inputs.artifacts-token }}" \
+        INPUTS_BUILD_HOST="${{ inputs.build-host }}" \
+        INPUTS_CONTAINER_REGISTRY_TOKEN="${{ inputs.container-registry-token }}" \
+        INPUTS_CONTAINER_REGISTRY_URL="${{ inputs.container-registry-url }}" \
+        INPUTS_DOCKERFILE_PATH="${{ inputs.dockerfile-path }}" \
+        INPUTS_DOCKERFILE_SLUG="${{ inputs.dockerfile-slug }}" \
+        INPUTS_DOCKER_ACCESS_TOKEN="${{ inputs.dockerfile-access-token }}" \
         INPUTS_DISTRO="${{ inputs.distro }}" \
-        INPUTS_OUTPUT_DIR="${{ inputs.output-dir }}" \
         INPUTS_GPG_KEY="${{ inputs.gpg-key }}" \
         INPUTS_GPG_NAME="${{ inputs.gpg-name }}" \
-        INPUTS_DOCKERFILE_SLUG="${{ inputs.dockerfile-slug }}" \
-        INPUTS_DOCKERFILE_PATH="${{ inputs.dockerfile-path }}" \
-        INPUTS_DOCKER_ACCESS_TOKEN="${{ inputs.dockerfile-access-token }}" \
-        INPUTS_CONTAINER_REGISTRY_URL="${{ inputs.container-registry-url }}" \
-        INPUTS_CONTAINER_REGISTRY_USER="${{ inputs.container-registry-user }}" \
-        INPUTS_CONTAINER_REGISTRY_TOKEN="${{ inputs.container-registry-token }}" \
-        INPUTS_BUILD_HOST="${{ inputs.build-host }}" \
-        INPUTS_ARTIFACTS_TOKEN="${{ inputs.artifacts-token }}" \
+        INPUTS_OUTPUT_DIR="${{ inputs.output-dir }}" \
+        INPUTS_PATH="${{ inputs.path }}" \
+        INPUTS_SPEC="${{ inputs.spec }}" \
+        INPUTS_TARGET_PROCESSOR_ARCH="${{ inputs.target-processor-arch }}"
         ${{ github.action_path }}/action.sh
 
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ arg_count=${#args[@]}
 url_index=$((arg_count - 1))
 url=${args[${url_index}]}
 
-token=`cat ~/.gh_token`
+token=$(cat ~/.gh_token)
 
 # URLS are not case sensative, convert to all lowercase
 # the string 'https://github.comcast.com/' is 19 characters long.
@@ -65,7 +65,11 @@ if [ ! -z "$INPUTS_BUILD_HOST" ]; then
 fi
 
 # Build the RPM and SRPM files.
-rpmbuild --undefine=_disable_source_fetch -ba $INPUTS_SPEC_FILE
+if [ ! -z "$INPUTS_TARGET_PROCESSOR_ARCH" ] ; then
+    rpmbuild --undefine=_disable_source_fetch --target=$INPUTS_TARGET_PROCESSOR_ARCH -ba $INPUTS_SPEC_FILE
+else
+    rpmbuild --undefine=_disable_source_fetch -ba $INPUTS_SPEC_FILE
+fi
 
 if [ ! -z "$INPUTS_GPG_KEY" ] ; then
     echo "Signing the RPMs."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ fi
 
 # Build the RPM and SRPM files.
 if [ ! -z "$INPUTS_TARGET_PROCESSOR_ARCH" ] ; then
-    rpmbuild --undefine=_disable_source_fetch --target=$INPUTS_TARGET_PROCESSOR_ARCH -ba $INPUTS_SPEC_FILE
+    rpmbuild --undefine=_disable_source_fetch --target $INPUTS_TARGET_PROCESSOR_ARCH -ba $INPUTS_SPEC_FILE
 else
     rpmbuild --undefine=_disable_source_fetch -ba $INPUTS_SPEC_FILE
 fi


### PR DESCRIPTION
## What is this PR out to accomplish?

This PR adds additional configuration to allow for targeting arbitrary processor architectures in the rpm building action. Specifically, we add the `target` param to `rpmbuild`'s invocation. Note: This configuration is of narrow utility, however, since any rpm `.spec` files that require cross-processor-arch compilation would require re-work of the build/invoke docker container.

The use case that this would address is when a `spec` file pulls a pre-baked arbitrary binary to be packaged, which is the one I'll be testing against.

Also: I alphabetized the params across their representations.
